### PR TITLE
[FIX] Fixed dimension size in joint alignment

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+Hotfix, January 2021 -- MATLAB Joint Alignment
+MATLAB:
+- Fixed faulty dimensionality extraction in joint alignment of asymmetric
+matrices. 
+
 v0.1.1, March 2020 -- Quality of life update
 MATLAB:
 - New functionality:

--- a/matlab/@GradientMaps/fit.m
+++ b/matlab/@GradientMaps/fit.m
@@ -85,7 +85,7 @@ if strcmp(obj.method.alignment,'Joint Alignment')
             rethrow(ME)
         end
     end
-    size_connectivity = cellfun(@(x)size(x,1),connectivity_matrix);
+    size_connectivity = cellfun(@(x)size(x,2),connectivity_matrix);
     clearvars connectivity_matrix
     connectivity_matrix{1} = tmp; 
 end


### PR DESCRIPTION
Fix for the bug mentioned in #28. In short, joint alignment was using the wrong size of the wrong dimension to determine which columns to extract from the computed gradients. This was fixed by simply changing the dimension extracted by size_connectivity. 