### PR TITLE
Grid layout for `plot_hemispheres`

### DIFF
--- a/brainspace/plotting/surface_plotting.py
+++ b/brainspace/plotting/surface_plotting.py
@@ -464,11 +464,11 @@ def plot_hemispheres(surf_lh, surf_rh, array_name=None, color_bar=False,
     label_text : dict[str, array-like], optional
         Label text for column/row. Possible keys are {'left', 'right',
         'top', 'bottom'}, which indicate the location. Default is None.
-    layout_style : str or None
-        Display style for hemispheres. If `row`, layout is a single row 
-        alternating lateral and medial views, from left to right. If `grid`, 
-        layout is a 2x2 grid, with lateral views in the top row, and medial 
-        views in the bottom row, and left and right columns. Default is `row` 
+    layout_style : str
+        Layout style for hemispheres. If 'row', layout is a single row 
+        alternating lateral and medial views, from left to right. If 'grid', 
+        layout is a 2x2 grid, with lateral views in the top row, medial 
+        views in the bottom row, and left and right columns. Default is 'row'. 
     nan_color : tuple
         Color for nan values. Default is (0, 0, 0, 1).
     zoom : float or sequence of float, optional

--- a/brainspace/plotting/surface_plotting.py
+++ b/brainspace/plotting/surface_plotting.py
@@ -469,8 +469,6 @@ def plot_hemispheres(surf_lh, surf_rh, array_name=None, color_bar=False,
         alternating lateral and medial views, from left to right. If 'grid', 
         layout is a 2x2 grid, with lateral views in the top row, medial 
         views in the bottom row, and left and right columns. Default is 'row'.
-        When using 'grid' style, only one `array_name` can be plotted. If  
-        array_name contains multiple entries, only use the first one. 
     nan_color : tuple
         Color for nan values. Default is (0, 0, 0, 1).
     zoom : float or sequence of float, optional
@@ -538,9 +536,17 @@ def plot_hemispheres(surf_lh, surf_rh, array_name=None, color_bar=False,
         array_name = np.asarray(array_name2)[:, None]
 
     if layout_style == 'grid':
-        array_name = np.full((2, 2), fill_value=array_name[0][0]) 
-        layout = np.array(layout).reshape(2, 2).T.tolist()
-        view = [['lateral', 'medial'], ['medial', 'lateral']]
+        
+        # create 2x2 grid for each array_name and stack altogether
+        n_arrays = len(array_name)
+        array_names, layouts = [], []
+        for a, l in zip(array_name, layout):
+            array_names.append(np.full((2, 2), fill_value=a[0]))
+            layouts.append(np.array(l).reshape(2, 2).T.tolist())
+        array_name = np.vstack(array_names)
+        layout = np.vstack(layouts)
+        
+        view = [['lateral', 'medial'], ['medial', 'lateral']] * n_arrays
         share = 'both'
     else:
         view = ['lateral', 'medial', 'lateral', 'medial']

--- a/brainspace/plotting/surface_plotting.py
+++ b/brainspace/plotting/surface_plotting.py
@@ -439,7 +439,7 @@ def plot_surf(surfs, layout, array_name=None, view=None, color_bar=None,
 
 @wrap_input(0, 1)
 def plot_hemispheres(surf_lh, surf_rh, array_name=None, color_bar=False,
-                     color_range=None, label_text=None,
+                     color_range=None, label_text=None, layout_style='row',
                      cmap='viridis', nan_color=(0, 0, 0, 1), zoom=1,
                      background=(1, 1, 1), size=(400, 400), interactive=True,
                      embed_nb=False, screenshot=False, filename=None,
@@ -464,6 +464,11 @@ def plot_hemispheres(surf_lh, surf_rh, array_name=None, color_bar=False,
     label_text : dict[str, array-like], optional
         Label text for column/row. Possible keys are {'left', 'right',
         'top', 'bottom'}, which indicate the location. Default is None.
+    layout_style : str or None
+        Display style for hemispheres. If `row`, layout is a single row 
+        alternating lateral and medial views, from left to right. If `grid`, 
+        layout is a 2x2 grid, with lateral views in the top row, and medial 
+        views in the bottom row, and left and right columns. Default is `row` 
     nan_color : tuple
         Color for nan values. Default is (0, 0, 0, 1).
     zoom : float or sequence of float, optional
@@ -532,10 +537,18 @@ def plot_hemispheres(surf_lh, surf_rh, array_name=None, color_bar=False,
                 array_name2.append(an)
         array_name = np.asarray(array_name2)[:, None]
 
+    if layout_style == 'grid':
+        array_name = np.full((2, 2), fill_value=array_name[0][0]) 
+        layout = np.array(layout).reshape(2, 2).T.tolist()
+        view = view = [['lateral', 'medial'], ['medial', 'lateral']]
+        share = 'both'
+    else:
+        share = 'r'
+        
     if isinstance(cmap, list):
         cmap = np.asarray(cmap)[:, None]
 
-    kwds = {'view': view, 'share': 'r'}
+    kwds = {'view': view, 'share': share}
     kwds.update(kwargs)
     return plot_surf(surfs, layout, array_name=array_name, color_bar=color_bar,
                      color_range=color_range, label_text=label_text, cmap=cmap,

--- a/brainspace/plotting/surface_plotting.py
+++ b/brainspace/plotting/surface_plotting.py
@@ -468,7 +468,9 @@ def plot_hemispheres(surf_lh, surf_rh, array_name=None, color_bar=False,
         Layout style for hemispheres. If 'row', layout is a single row 
         alternating lateral and medial views, from left to right. If 'grid', 
         layout is a 2x2 grid, with lateral views in the top row, medial 
-        views in the bottom row, and left and right columns. Default is 'row'. 
+        views in the bottom row, and left and right columns. Default is 'row'.
+        When using 'grid' style, only one `array_name` can be plotted. If  
+        array_name contains multiple entries, only use the first one. 
     nan_color : tuple
         Color for nan values. Default is (0, 0, 0, 1).
     zoom : float or sequence of float, optional
@@ -510,13 +512,11 @@ def plot_hemispheres(surf_lh, surf_rh, array_name=None, color_bar=False,
     :func:`plot_surf`
 
     """
-
     if color_bar is True:
         color_bar = 'right'
 
     surfs = {'lh': surf_lh, 'rh': surf_rh}
     layout = ['lh', 'lh', 'rh', 'rh']
-    view = ['lateral', 'medial', 'lateral', 'medial']
 
     if isinstance(array_name, np.ndarray):
         if array_name.ndim == 2:
@@ -540,11 +540,12 @@ def plot_hemispheres(surf_lh, surf_rh, array_name=None, color_bar=False,
     if layout_style == 'grid':
         array_name = np.full((2, 2), fill_value=array_name[0][0]) 
         layout = np.array(layout).reshape(2, 2).T.tolist()
-        view = view = [['lateral', 'medial'], ['medial', 'lateral']]
+        view = [['lateral', 'medial'], ['medial', 'lateral']]
         share = 'both'
     else:
+        view = ['lateral', 'medial', 'lateral', 'medial']
         share = 'r'
-        
+
     if isinstance(cmap, list):
         cmap = np.asarray(cmap)[:, None]
 


### PR DESCRIPTION
References #37, in which `plot_hemispheres` can additionally plot brains as a 2x2 grid. This PR includes an additional argument, `layout_style` which can be set as 'row' (i.e. the current layout), or 'grid' (i.e. the 2x2 layout). A minimal example with a colorbar:

```python
from brainspace import plotting, datasets

lh, rh = datasets.load_conte69()
labeling = datasets.load_parcellation('schaefer', scale=400, join=True)

plotting.plot_hemispheres(lh, rh, array_name=labeling, 
                          zoom=1.7, size=(500, 300), 
                          color_bar='right', layout_style='grid')
```
Output:
![grid](https://user-images.githubusercontent.com/14634382/112659766-157a3300-8e2b-11eb-9f42-0c5be9356ce5.png)

Conveniently, handling labels didn't require any changes. Labels can still be passed as lists, such that colums and rows are each labelled:

```python
plotting.plot_hemispheres(lh, rh, array_name=labeling, 
                          zoom=1.3, size=(600, 500), 
                          color_bar='right', layout_style='grid', 
                          label_text={'left': ['Lateral', 'Medial'], 'top': ['Left', 'Right']}, 
                          screenshot=True, filename='grid_labels.png')
```
Output:
![grid_labels](https://user-images.githubusercontent.com/14634382/112659772-17dc8d00-8e2b-11eb-9bd7-6f86931b47bc.png)

Wasn't sure where to call `layout_style` or layout