### PR TITLE
[ENH] Error when affinity matrix contains nan/inf

### DIFF
--- a/brainspace/gradient/gradient.py
+++ b/brainspace/gradient/gradient.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy.sparse as sp
 
 from sklearn.base import BaseEstimator
 
@@ -44,6 +43,11 @@ def _fit_one(x, app, kernel, n_components, random_state, gamma=None,
     """
 
     a = compute_affinity(x, kernel=kernel, sparsity=sparsity, gamma=gamma)
+
+    if np.isnan(a).any() or np.isinf(a).any():
+        raise ValueError(
+            "Affinity matrix contains NaN or Inf values. Common causes of this include NaNs/Infs or rows of zeros in the input matrix."
+        )
 
     kwds_emb = {'n_components': n_components, 'random_state': random_state}
     kwds_emb.update(kwargs)


### PR DESCRIPTION
Currently, if the affinity matrix contains Infs/NaNs then it's used in dimensionality reduction anyway, which results in gradients that are all NaNs. It's not intuitive for the user what's going wrong here.

This PR adds an error in `brainspace.gradient.gradient._fit_one` when the affinity matrix contains Infs/NaNs in. It also removes an unused import in the same file. 

- Resolves #62 .