### PR TITLE
[FIX] Fixed a bug that caused conncomp to error

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,9 +1,18 @@
+v0.1.4, April 2022 -- Bug Fixes
+MATLAB:
+  - Fixed a bug that caused the detection of connected affinity matrices to error.
+
+v0.1.3, January 2022 -- Fix dependency error
+Python:
+  - Fixed an issue caused by an update to scikit-learn's kmeans function.
+
+
 Hotfix, September 2021 -- MATLAB eigenvalues
-MATLAB
+MATLAB:
 - Fixed an inaccuracy in the computation of the eigenvalues in diffusion mapping.
 
 v0.1.2, July 2022
-MATLAB
+MATLAB:
   - Added a verbose flag to GradientMaps (default value: false).
   - plot_hemispheres has several new functionalities:
       - Now returns an object rather than the graphics handles.

--- a/docs/pages/matlab_doc/examples/tutorial_1_gradient_creation.rst
+++ b/docs/pages/matlab_doc/examples/tutorial_1_gradient_creation.rst
@@ -27,7 +27,7 @@ Let's first look at the parcellation scheme we're using.
 .. code-block:: matlab    
     
     h = plot_hemispheres(labeling, {surf_lh,surf_rh});
-    colormap(h.figure,lines(401))
+    colormap(h.handles.figure,lines(401))
 
 .. image:: ./example_figs/schaefer_400.png
     :scale: 70%

--- a/matlab/@GradientMaps/GradientMaps.m
+++ b/matlab/@GradientMaps/GradientMaps.m
@@ -286,11 +286,8 @@ classdef GradientMaps
                 end
             end
             
-            % Check if the graph is connected. Large matrices may remain
-            % floating point asymmetric despite the above check, so only
-            % use lower.
-            if ~all(conncomp(graph(abs(data),'lower')) == 1) 
-                error('Graph is not connected.')
+            if ~graph_is_connected(data)
+                error('Affinity matrix is not a connected graph.');
             end
             
             %% Embedding.

--- a/matlab/analysis_code/graph_is_connected.m
+++ b/matlab/analysis_code/graph_is_connected.m
@@ -1,0 +1,30 @@
+function is_connected = graph_is_connected(G)
+% GRAPH_IS_CONNECTED    Assesses whether a graph is fully connected.
+%
+%   is_connected = GRAPH_IS_CONNECTED(graph) tests whether the graph is
+%   fully connected. Graph must be a graph, a 2D logical matrix, or a data type that
+%   may be converted to a 2D logical matrix; is_connected is true if the graph is
+%   connected, otherwise false.
+
+if isa(G, 'graph')
+    G = adjacency(G);
+end
+G = logical(G);
+
+vertex = 1;
+visited = zeros(size(G, 1), 1, 'logical');
+
+visited = depth_first_search(G, vertex, visited);
+is_connected = all(visited);
+end
+
+function visited = depth_first_search(graph, vertex, visited)
+% Conducts a depth first search on the graph.
+visited(vertex) = true;
+adjacent_vertices = find(graph(vertex, :));
+for adjacent_vertex = adjacent_vertices
+    if ~visited(adjacent_vertex)
+        visited = depth_first_search(graph, adjacent_vertex, visited);
+    end
+end
+end

--- a/matlab/analysis_code/graph_is_connected.m
+++ b/matlab/analysis_code/graph_is_connected.m
@@ -9,7 +9,6 @@ function is_connected = graph_is_connected(G)
 if isa(G, 'graph')
     G = adjacency(G);
 end
-G = logical(G);
 
 vertex = 1;
 visited = zeros(size(G, 1), 1, 'logical');

--- a/matlab/tests/@utils_tests/utils_tests.m
+++ b/matlab/tests/@utils_tests/utils_tests.m
@@ -1,0 +1,26 @@
+classdef utils_tests < matlab.unittest.TestCase
+
+    methods(Test)
+        function test_graph_is_connected(testCase)
+            % Tests the graph_is_connected function against MathWorks'
+            % conncomp.
+            
+            one_disconnected = ones(5);
+            one_disconnected(:,5) = 0;
+            one_disconnected(5,:) = 0;
+
+            test_graphs = {
+                magic(5) + magic(5)', ... % connected
+                eye(5), ... % Not connected
+                one_disconnected
+            };
+
+            for G = test_graphs
+                testCase.assertEqual( ...
+                    all(conncomp(graph(G{1}))==1), ...
+                    graph_is_connected(G{1}) ...
+                );
+            end
+        end
+    end
+end

--- a/matlab/tests/@utils_tests/utils_tests.m
+++ b/matlab/tests/@utils_tests/utils_tests.m
@@ -12,13 +12,21 @@ classdef utils_tests < matlab.unittest.TestCase
             test_graphs = {
                 magic(5) + magic(5)', ... % connected
                 eye(5), ... % Not connected
-                one_disconnected
+                one_disconnected, ...
+                graph(one_disconnected)
             };
 
             for G = test_graphs
+                if isa(G{1}, 'graph')
+                    mathworks_answer = all(conncomp(G{1})==1);
+                else
+                    mathworks_answer = all(conncomp(graph(G{1}))==1);
+                end
+                brainspace_answer = graph_is_connected(G{1});
+
                 testCase.assertEqual( ...
-                    all(conncomp(graph(G{1}))==1), ...
-                    graph_is_connected(G{1}) ...
+                    mathworks_answer, ...
+                    brainspace_answer ...
                 );
             end
         end


### PR DESCRIPTION
- Resolves #24 

MATLAB's conncomp errors for some users. Although I have not been able to reproduce this bug, it's been reported often enough to be worth resolving. This PR switches from MATLAB's conncomp to a custom connected graph detection algorithm.