### PR TITLE
[TST] Remove 3.6 unit tests, add 3.10 unit tests.

### DIFF
--- a/.github/workflows/github_actions_ci.yml
+++ b/.github/workflows/github_actions_ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds Python 3.10 to the unit tests and removes Python 3.6. Python 3.6 has reached its end of life almost a year ago so maintaining support seems unnecessary. 