### PR TITLE
[TST] Add Python 3.11 unit tests

### DIFF
--- a/.github/workflows/github_actions_ci.yml
+++ b/.github/workflows/github_actions_ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/github_actions_ci.yml
+++ b/.github/workflows/github_actions_ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Currently failing as there's no Python 3.11 wheels for VTK.