### PR TITLE
Speed up cosine affinity in kernels

### DIFF
--- a/brainspace/gradient/kernels.py
+++ b/brainspace/gradient/kernels.py
@@ -24,7 +24,6 @@ def _build_kernel(x, kernel, gamma=None):
         return np.corrcoef(x)
 
     if kernel in {'cosine', 'normalized_angle'}:
-        if kernel == 'cosine':
             x = cosine_similarity(x)
         if kernel == 'normalized_angle':
             x = 1 - np.arccos(x, x)/np.pi

--- a/brainspace/gradient/kernels.py
+++ b/brainspace/gradient/kernels.py
@@ -24,7 +24,8 @@ def _build_kernel(x, kernel, gamma=None):
         return np.corrcoef(x)
 
     if kernel in {'cosine', 'normalized_angle'}:
-        x = cosine_similarity(x)
+        if kernel == 'cosine':
+            x = cosine_similarity(x)
         if kernel == 'normalized_angle':
             x = 1 - np.arccos(x, x)/np.pi
         return x

--- a/brainspace/gradient/kernels.py
+++ b/brainspace/gradient/kernels.py
@@ -10,7 +10,7 @@ import numpy as np
 import scipy.sparse as sp
 from scipy.stats import rankdata
 from scipy.spatial.distance import pdist, squareform
-
+from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.metrics.pairwise import rbf_kernel
 
 from .utils import dominant_set
@@ -24,7 +24,7 @@ def _build_kernel(x, kernel, gamma=None):
         return np.corrcoef(x)
 
     if kernel in {'cosine', 'normalized_angle'}:
-        x = 1 - squareform(pdist(x, metric='cosine'))
+        x = cosine_similarity(x)
         if kernel == 'normalized_angle':
             x = 1 - np.arccos(x, x)/np.pi
         return x

--- a/brainspace/gradient/kernels.py
+++ b/brainspace/gradient/kernels.py
@@ -24,7 +24,7 @@ def _build_kernel(x, kernel, gamma=None):
         return np.corrcoef(x)
 
     if kernel in {'cosine', 'normalized_angle'}:
-            x = cosine_similarity(x)
+        x = cosine_similarity(x)
         if kernel == 'normalized_angle':
             x = 1 - np.arccos(x, x)/np.pi
         return x


### PR DESCRIPTION
I replaced `x = 1 - squareform(pdist(x, metric='cosine'))` with `x = cosine_similarity(x)` from `sklearn.metrics.pairwise`. This speeds up computation considerably when done on high-res surfaces (fsLR 32k).