### PR TITLE
removed valueError for nonzero eigenvalues

### DIFF
--- a/brainspace/null_models/moran.py
+++ b/brainspace/null_models/moran.py
@@ -99,9 +99,6 @@ def compute_mem(w, n_ring=1, spectrum='nonzero', tol=1e-10):
     mask_zero = ev_abs < tol
     n_zero = np.count_nonzero(mask_zero)
 
-    if n_zero == 0:
-        raise ValueError('Weight matrix has no zero eigenvalue.')
-
     # Multiple zero eigenvalues
     if spectrum == 'all':
         if n_zero > 1:


### PR DESCRIPTION
I was rtying to run this for hippocampal surfaces with no masked data (i.e. no medial wall) and received an error on this line. I believe it is an unneeded line.