### PR TITLE
feat: enable Qt backend for image rendering

### DIFF
--- a/brainspace/plotting/base.py
+++ b/brainspace/plotting/base.py
@@ -83,7 +83,7 @@ def _get_qt_app():
     if in_ipython():
         from IPython import get_ipython
         ipython = get_ipython()
-        ipython.magic('gui qt')
+        ipython.run_line_magic('gui', 'qt')
 
         from IPython.external.qt_for_kernel import QtGui
         app = QtGui.QApplication.instance()
@@ -184,9 +184,9 @@ class Plotter(object):
     def __init__(self, nrow=1, ncol=1, offscreen=None, force_close=False,
                  try_qt=False, **kwargs):
 
-        if try_qt:
-            warnings.warn('Qt rendering is not supported for the moment.')
-            try_qt = False
+        # if try_qt:
+        #     warnings.warn('Qt rendering is not supported for the moment.')
+        #     try_qt = False
 
         self.grid = _create_grid(nrow, ncol)
         self.nrow, self.ncol = self.grid.shape[:2]
@@ -329,6 +329,7 @@ class Plotter(object):
             self.ren_win.Render()
             if self.use_qt:
                 self.app_window.show()
+                self.app.exec_()
             else:
                 self.iren.Start()
 


### PR DESCRIPTION
When I try to create a `Plotter` object and call its `.show()` method, an interactive windos pops up as expected. However, after I mamually close the window, the program hangs and does not proceed.

I found that the issue occurs [here](https://github.com/MICA-MNI/BrainSpace/blob/master/brainspace/plotting/base.py#L333). Specifically, when the poped window is closed manually, the code does not terminate as expected and gets stuck at this line, never moving forward. The root cause might be related to VTK's event handling, but I am not very familiar with VTK.

To make the `.show()` method usable, I attempted to use Qt to rendering, which led to this PR. The goal is to leverage Qt's event loop to ensure the program can continue properly after the window is closed.