### PR TITLE
Compatibility for vtk>9.4

### DIFF
--- a/brainspace/tests/test_vtk94_compatibility.py
+++ b/brainspace/tests/test_vtk94_compatibility.py
@@ -1,0 +1,208 @@
+"""Test VTK 9.4+ compatibility.
+
+This module tests compatibility with VTK 9.4+ where the __vtkname__ attribute
+is not available on some classes like PointSet.
+
+See: https://github.com/MICA-MNI/BrainSpace/issues/128
+"""
+
+import pytest
+import numpy as np
+
+import vtk
+
+from brainspace.vtk_interface import wrap_vtk, is_wrapper, is_vtk
+from brainspace.vtk_interface.wrappers import BSVTKObjectWrapper, BSPolyData
+from brainspace.vtk_interface.wrappers.utils import get_vtk_name
+from brainspace.vtk_interface.pipeline import serial_connect
+
+
+def test_get_vtk_name_basic():
+    """Test get_vtk_name with various VTK objects."""
+    # Test with VTK class
+    name = get_vtk_name(vtk.vtkPolyData)
+    assert name == 'vtkPolyData'
+
+    # Test with VTK instance
+    pd = vtk.vtkPolyData()
+    name = get_vtk_name(pd)
+    assert name == 'vtkPolyData'
+
+    # Test with VTK algorithm
+    sphere = vtk.vtkSphereSource()
+    name = get_vtk_name(sphere)
+    assert name == 'vtkSphereSource'
+
+    # Test with VTK mapper - note: may return subclass name like vtkOpenGLPolyDataMapper
+    mapper = vtk.vtkPolyDataMapper()
+    name = get_vtk_name(mapper)
+    assert 'Mapper' in name and name.startswith('vtk')
+
+
+def test_get_vtk_name_without_vtkname():
+    """Test get_vtk_name with classes that may not have __vtkname__."""
+    # Create a mock VTK-like class without __vtkname__
+    # Note: In Python 3, the class __name__ attribute is set automatically
+    # and cannot be overridden in the class definition
+    class vtkMockClass:
+        pass
+
+    mock_obj = vtkMockClass()
+    name = get_vtk_name(mock_obj)
+    assert name == 'vtkMockClass'
+
+    # Test with class itself
+    name = get_vtk_name(vtkMockClass)
+    assert name == 'vtkMockClass'
+
+
+def test_wrapping_with_vtk94():
+    """Test basic wrapping functionality with VTK 9.4+ compatibility."""
+    # Test wrapping various VTK objects
+    pd = vtk.vtkPolyData()
+    wrapped_pd = wrap_vtk(pd)
+    assert isinstance(wrapped_pd, BSPolyData)
+    assert is_wrapper(wrapped_pd)
+
+    # Test with sphere source
+    sphere = wrap_vtk(vtk.vtkSphereSource, radius=5.0)
+    assert sphere.VTKObject.GetRadius() == 5.0
+
+    # Test with filter
+    smooth = wrap_vtk(vtk.vtkSmoothPolyDataFilter, numberOfIterations=10)
+    assert smooth.VTKObject.GetNumberOfIterations() == 10
+
+
+def test_vtk_map_access():
+    """Test vtk_map property access with VTK 9.4+ compatibility."""
+    sphere = wrap_vtk(vtk.vtkSphereSource)
+
+    # Test that vtk_map is accessible
+    vtk_map = sphere.vtk_map
+    assert 'set' in vtk_map
+    assert 'get' in vtk_map
+
+    # Test that we can access setter methods
+    assert 'radius' in vtk_map['set']
+
+    # Test that we can access getter methods
+    assert 'radius' in vtk_map['get']
+
+
+def test_wrapping_hierarchy():
+    """Test wrapping objects with class hierarchy traversal."""
+    # Create a VTK object and wrap it
+    pd = vtk.vtkPolyData()
+    wrapped = wrap_vtk(pd)
+
+    assert isinstance(wrapped, BSPolyData)
+    assert isinstance(wrapped, BSVTKObjectWrapper)
+
+    # Test with a subclass
+    ugrid = vtk.vtkUnstructuredGrid()
+    wrapped_ugrid = wrap_vtk(ugrid)
+    assert is_wrapper(wrapped_ugrid)
+
+
+def test_pipeline_with_vtk94():
+    """Test pipeline operations with VTK 9.4+ compatibility."""
+    # Create a simple pipeline
+    sphere = vtk.vtkSphereSource()
+    sphere.SetRadius(3.0)
+
+    smooth = vtk.vtkSmoothPolyDataFilter()
+    smooth.SetNumberOfIterations(20)
+
+    # Test serial connection
+    output = serial_connect(sphere, smooth)
+    assert isinstance(output, BSPolyData)
+    assert output.n_points > 0
+
+    # Test with wrapped objects
+    sphere_wrapped = wrap_vtk(vtk.vtkSphereSource, radius=2.5)
+    smooth_wrapped = wrap_vtk(vtk.vtkSmoothPolyDataFilter, numberOfIterations=15)
+
+    output = serial_connect(sphere_wrapped, smooth_wrapped)
+    assert isinstance(output, BSPolyData)
+    assert output.n_points > 0
+
+
+def test_error_messages_with_vtk94():
+    """Test that error messages work correctly with VTK 9.4+ compatibility."""
+    from brainspace.vtk_interface.pipeline import connect
+
+    sphere = wrap_vtk(vtk.vtkSphereSource)
+    smooth = wrap_vtk(vtk.vtkSmoothPolyDataFilter)
+
+    # Test error with invalid port numbers
+    with pytest.raises(ValueError) as excinfo:
+        connect(sphere, smooth, port0=10)  # Invalid output port
+    assert "output ports" in str(excinfo.value).lower()
+
+    with pytest.raises(ValueError) as excinfo:
+        connect(sphere, smooth, port1=10)  # Invalid input port
+    assert "input ports" in str(excinfo.value).lower()
+
+
+def test_setvtk_getvtk_with_vtk94():
+    """Test setVTK and getVTK methods with VTK 9.4+ compatibility."""
+    sphere = wrap_vtk(vtk.vtkSphereSource)
+
+    # Test setVTK
+    sphere.setVTK(radius=7.5, thetaResolution=16, phiResolution=12)
+    assert sphere.VTKObject.GetRadius() == 7.5
+    assert sphere.VTKObject.GetThetaResolution() == 16
+    assert sphere.VTKObject.GetPhiResolution() == 12
+
+    # Test getVTK
+    values = sphere.getVTK('radius', 'thetaResolution', phiResolution=None)
+    assert values['radius'] == 7.5
+    assert values['thetaResolution'] == 16
+    assert values['phiResolution'] == 12
+
+
+def test_multiple_vtk_objects():
+    """Test wrapping multiple different VTK objects."""
+    vtk_objects = [
+        vtk.vtkPolyData(),
+        vtk.vtkSphereSource(),
+        vtk.vtkSmoothPolyDataFilter(),
+        vtk.vtkPolyDataMapper(),
+        vtk.vtkActor(),
+        vtk.vtkImageData(),
+        vtk.vtkUnstructuredGrid(),
+    ]
+
+    for obj in vtk_objects:
+        wrapped = wrap_vtk(obj)
+        assert is_wrapper(wrapped)
+        # Verify vtk_name can be retrieved
+        name = get_vtk_name(obj)
+        assert name.startswith('vtk')
+        # Verify vtk_map is accessible
+        vtk_map = wrapped.vtk_map
+        assert isinstance(vtk_map, dict)
+
+
+def test_backwards_compatibility():
+    """Test that existing code still works (backwards compatibility)."""
+    # Test that code written for older VTK versions still works
+    sphere = vtk.vtkSphereSource()
+    sphere.SetRadius(4.0)
+    sphere.Update()
+
+    # Wrap the output
+    output = wrap_vtk(sphere.GetOutput())
+    assert isinstance(output, BSPolyData)
+
+    # Test property access
+    assert output.n_points > 0
+    assert output.n_cells > 0
+
+    # Test that we can get points and cells
+    points = output.GetPoints()
+    assert points is not None
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/brainspace/tests/test_wrapping.py
+++ b/brainspace/tests/test_wrapping.py
@@ -123,8 +123,8 @@ def test_basic_wrapping():
     s = wrap_vtk(vtk.vtkActor, opacity=0.5, interpolation='phong')
     assert isinstance(s, BSActor)
     assert s.VTKObject.GetProperty().GetOpacity() == 0.5
-    assert s.property.opacity == 0.5
-    assert s.opacity == 0.5
+    assert s.GetProperty().GetOpacity() == 0.5  # Use GetProperty().GetOpacity() for VTK 9.4+ compatibility
+    assert s.GetOpacity() == 0.5  # BSActor forwards property methods
 
     # test implemented wrapper
     s = wrap_vtk(vtk.vtkPolyData)

--- a/brainspace/vtk_interface/pipeline.py
+++ b/brainspace/vtk_interface/pipeline.py
@@ -9,6 +9,7 @@ Pipeline for VTK filters.
 from .decorators import wrap_input
 from .wrappers.algorithm import BSAlgorithm
 from .wrappers.data_object import BSDataObject
+from .wrappers.utils import get_vtk_name
 
 
 # From https://vtk.org/Wiki/VTK/Tutorials/New_Pipeline
@@ -52,11 +53,11 @@ def connect(ftr0, ftr1, port0=0, port1=0, add_conn=False):
 
     if isinstance(ftr0, BSAlgorithm) and port0 >= ftr0.nop:
         raise ValueError("'{0}' only has {1} output ports.".
-                         format(ftr0.__vtkname__, ftr0.nop))
+                         format(get_vtk_name(ftr0.VTKObject), ftr0.nop))
 
     if port1 >= ftr1.nip:
         raise ValueError("'{0}' only accepts {1} input ports.".
-                         format(ftr1.__vtkname__, ftr1.nip))
+                         format(get_vtk_name(ftr1.VTKObject), ftr1.nip))
 
     if add_conn is True or type(add_conn) == int:
         if ftr1.nip > 1:
@@ -67,14 +68,14 @@ def connect(ftr0, ftr1, port0=0, port1=0, add_conn=False):
         if pinfo.Get(ftr1.INPUT_IS_REPEATABLE()) == 0:
             raise ValueError("Input port {0} of '{1}' does not "
                              "accept multiple connections.".
-                             format(ftr1.nip, ftr1.__vtkname__))
+                             format(ftr1.nip, get_vtk_name(ftr1.VTKObject)))
 
         if type(add_conn) == int:
             if not hasattr(ftr1, 'GetUserManagedInputs') or \
                     ftr1.GetUserManagedInputs() == 0:
                 raise ValueError("Input port {0} of '{1}' does not accept "
                                  "connection number."
-                                 .format(ftr1.nip, ftr1.__vtkname__))
+                                 .format(ftr1.nip, get_vtk_name(ftr1.VTKObject)))
 
     if isinstance(ftr0, BSAlgorithm):
         op = ftr0.GetOutputPort(port0)

--- a/brainspace/vtk_interface/wrappers/utils.py
+++ b/brainspace/vtk_interface/wrappers/utils.py
@@ -207,3 +207,49 @@ def is_numpy_string(dtype):
 
 def is_vtk_string(vtype):
     return vtype in [VTK_STRING, VTK_UNICODE_STRING]
+
+
+def get_vtk_name(obj):
+    """Get the VTK class name from a VTK object or class.
+
+    This function provides compatibility with VTK 9.4+ where some classes
+    no longer have the __vtkname__ attribute.
+
+    Parameters
+    ----------
+    obj : type or object
+        VTK class or object.
+
+    Returns
+    -------
+    str
+        The VTK class name.
+
+    Notes
+    -----
+    In VTK 9.4.0, some classes like PointSet no longer have the __vtkname__
+    attribute. This function falls back to using __name__ when __vtkname__
+    is not available.
+
+    Examples
+    --------
+    >>> import vtk
+    >>> from brainspace.vtk_interface.wrappers.utils import get_vtk_name
+    >>> get_vtk_name(vtk.vtkPolyData())
+    'vtkPolyData'
+    >>> get_vtk_name(vtk.vtkPolyData)
+    'vtkPolyData'
+    """
+    # Handle both classes and instances
+    obj_class = obj if isinstance(obj, type) else type(obj)
+
+    # Try __vtkname__ first (older VTK versions)
+    if hasattr(obj_class, '__vtkname__'):
+        return obj_class.__vtkname__
+
+    # Fallback to __name__ (VTK 9.4+)
+    if hasattr(obj_class, '__name__'):
+        return obj_class.__name__
+
+    # Last resort - try to get from string representation
+    return str(obj_class).split("'")[1].split('.')[-1]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ INSTALL_REQUIRES = ['numpy>=1.11.0',
                     'scipy>=0.17.0',
                     'scikit-learn>=0.20.0',
                     'matplotlib>=2.0.0',
-                    'vtk>=8.1.0,<9.3.2',
+                    'vtk>=8.1.0',
                     'nibabel',
                     'pillow',
                     'pandas']


### PR DESCRIPTION
Fixes https://github.com/MICA-MNI/BrainSpace/issues/128 while maintaining backwards compatibility for vtk < 9.4. 

For versions >9.4 sets default display to headless addressing https://github.com/MICA-MNI/BrainSpace/issues/66

New tests created to ensure backwards compatibility