### PR TITLE
Fix MATLAB diffusion_mapping: complex eigenvalues (#98) and sqrt(N) component cap (#94)

### DIFF
--- a/matlab/analysis_code/diffusion_mapping.m
+++ b/matlab/analysis_code/diffusion_mapping.m
@@ -9,7 +9,7 @@ function [embedding, scaled_eigval] = diffusion_mapping(data, n_components, alph
 %   0 for automatic diffusion time estimation.
 %
 %   [embedding, scaled_eigval] = DIFFUSION_MAPPING(data,n_components,alpha, ...
-%   diffusion_time) also returns the eigenvalues scaled_eigval. 
+%   diffusion_time) also returns the eigenvalues scaled_eigval.
 %
 %   For complete documentation please consult our <a
 %   href="https://brainspace.readthedocs.io/en/latest/pages/matlab_doc/support_functions/diffusion_mapping.html">ReadTheDocs</a>.
@@ -24,44 +24,43 @@ sz = size(data);
 d = sum(data,2) .^ -alpha;
 L = data .* (d*d.');
 
-d2 = sum(L,2) .^ -1;
-M = bsxfun(@times, L, d2);
+% Markov matrix M = D^{-1} * L is asymmetric in general, so eig(M) can
+% return tiny imaginary parts and an unsorted spectrum (issue #98). Solve
+% the eigenproblem on the symmetric similar matrix
+%   Ms = D^{-1/2} * L * D^{-1/2}
+% which has the same (real) eigenvalues; eigenvectors map back via
+%   psi = D^{-1/2} * u.
+d_sqrt_inv = sum(L,2) .^ -0.5;
+Ms = (d_sqrt_inv * d_sqrt_inv.') .* L;
+% Force exact symmetry to suppress numerical asymmetry from outer products.
+Ms = (Ms + Ms.') / 2;
 
-% Get the eigenvectors and eigenvalues
-[eigvec,eigval] = eig(M);
-eigval = diag(eigval);
+% Symmetric eigendecomposition: eigenvalues are real.
+[eigvec_s, eigval] = eig(Ms, 'vector');
+eigvec = eigvec_s .* d_sqrt_inv;
 
 % Sort eigenvectors and values.
-[eigval, idx] = sort(eigval,'descend');
+[eigval, idx] = sort(real(eigval),'descend');
 eigvec = eigvec(:,idx);
-
-% Remove small eigenvalues.
-n = max(2, floor(sqrt(sz(1))));
-eigval = eigval(1:n);
-lambda = eigval(2:end); 
-eigvec = eigvec(:,1:n);
 
 % Scale eigenvectors by the largest eigenvector.
 psi = bsxfun(@rdivide, eigvec, eigvec(:,1));
 
 % Automatically determines the diffusion time and scales the eigenvalues.
 if diffusion_time == 0
-    % diffusion_time = exp(1 - log(1 - eigval(2:end)) ./ log(eigval(2:end)));
     scaled_eigval = eigval(2:end) ./ (1 - eigval(2:end));
 else
     scaled_eigval = eigval(2:end) .^ diffusion_time;
 end
 
 % Calculate embedding and bring the data towards output format.
-try
-    embedding = bsxfun(@times, psi(:,2:(n_components+1)), scaled_eigval(1:n_components).');
-catch ME
-    if strcmp(ME.identifier,'MATLAB:badsubscript')
-        warning(['An error ocurred. Most likely you requested more components' ...
-                 ' than could be computed. Attempting to return all available ' ...
-                 'components.']);
-        embedding = bsxfun(@times, psi(:,2:end),scaled_eigval(1:end).');
-    else
-        rethrow(ME);
-    end
+n_available = numel(scaled_eigval);
+if n_components > n_available
+    warning(['You requested %d components but only %d are available; ' ...
+             'returning all available components.'], ...
+            n_components, n_available);
+    n_components = n_available;
+end
+embedding = bsxfun(@times, psi(:,2:(n_components+1)), ...
+                   scaled_eigval(1:n_components).');
 end

--- a/matlab/analysis_code/diffusion_mapping.m
+++ b/matlab/analysis_code/diffusion_mapping.m
@@ -18,11 +18,22 @@ if exist('random_state','var')
     rng(random_state);
 end
 
-% Parameter for later use.
-sz = size(data);
+% Reject zero-sum rows up front: ^-alpha or ^-0.5 of a zero row sum
+% silently produces Inf/NaN and corrupts the embedding.
+row_sum_data = sum(data, 2);
+if any(row_sum_data <= 0)
+    error('diffusion_mapping:zeroRowSum', ...
+          'Affinity matrix has rows that sum to zero or below.');
+end
 
-d = sum(data,2) .^ -alpha;
+d = row_sum_data .^ -alpha;
 L = data .* (d*d.');
+
+row_sum_L = sum(L, 2);
+if any(row_sum_L <= 0)
+    error('diffusion_mapping:zeroRowSum', ...
+          'Normalized affinity has rows that sum to zero or below.');
+end
 
 % Markov matrix M = D^{-1} * L is asymmetric in general, so eig(M) can
 % return tiny imaginary parts and an unsorted spectrum (issue #98). Solve
@@ -30,18 +41,27 @@ L = data .* (d*d.');
 %   Ms = D^{-1/2} * L * D^{-1/2}
 % which has the same (real) eigenvalues; eigenvectors map back via
 %   psi = D^{-1/2} * u.
-d_sqrt_inv = sum(L,2) .^ -0.5;
-Ms = (d_sqrt_inv * d_sqrt_inv.') .* L;
-% Force exact symmetry to suppress numerical asymmetry from outer products.
+d_sqrt_inv = row_sum_L .^ -0.5;
+Ms = bsxfun(@times, bsxfun(@times, L, d_sqrt_inv), d_sqrt_inv.');
+
+% Ms is symmetric in exact arithmetic; symmetrize to suppress the small
+% asymmetry from finite-precision multiplication, but assert the gap is
+% genuinely numerical (catches upstream bugs that would otherwise hide).
+asym = norm(Ms - Ms.', 'fro');
+sym_tol = 1e-8 * max(norm(Ms, 'fro'), 1);
+assert(asym <= sym_tol, ...
+       'diffusion_mapping:asymmetry', ...
+       'Symmetric matrix has unexpected asymmetry (||Ms - Ms''||_F = %g).', asym);
 Ms = (Ms + Ms.') / 2;
 
 % Symmetric eigendecomposition: eigenvalues are real.
 [eigvec_s, eigval] = eig(Ms, 'vector');
-eigvec = eigvec_s .* d_sqrt_inv;
+eigvec = bsxfun(@times, eigvec_s, d_sqrt_inv);
 
-% Sort eigenvectors and values.
-[eigval, idx] = sort(real(eigval),'descend');
-eigvec = eigvec(:,idx);
+% Sort eigenvectors and values. eig(Ms,'vector') already returns reals,
+% but cast defensively in case of borderline 1e-300 imaginary residue.
+[eigval, idx] = sort(real(eigval), 'descend');
+eigvec = eigvec(:, idx);
 
 % Scale eigenvectors by the largest eigenvector.
 psi = bsxfun(@rdivide, eigvec, eigvec(:,1));

--- a/matlab/tests/@diffusion_mapping_tests/diffusion_mapping_tests.m
+++ b/matlab/tests/@diffusion_mapping_tests/diffusion_mapping_tests.m
@@ -1,0 +1,57 @@
+classdef diffusion_mapping_tests < matlab.unittest.TestCase
+    % Regression tests for matlab/analysis_code/diffusion_mapping.m
+    % Covers issues #98 (complex eigenvalues) and #94 (sqrt(N) component cap).
+
+    methods(Test)
+        function test_real_eigenvalues_on_cosine_similarity(testCase)
+            % Issue #98: a positive symmetric (cosine-similarity-like)
+            % input must yield real, descending-sorted eigenvalues.
+            rng(0);
+            X = randn(20, 50);
+            Xn = X ./ vecnorm(X, 2, 2);
+            S = (Xn * Xn.' + 1) / 2;        % positive cosine similarity in [0, 1]
+            S = (S + S.') / 2;
+            S(1:size(S,1)+1:end) = 1;        % unit diagonal
+
+            [embedding, eigval] = diffusion_mapping(S, 3, 0.5, 0);
+
+            testCase.verifyTrue(isreal(eigval), ...
+                'Eigenvalues must be real.');
+            testCase.verifyTrue(isreal(embedding), ...
+                'Embedding must be real.');
+            testCase.verifyEqual(eigval, sort(eigval, 'descend'), ...
+                'AbsTol', 1e-12, ...
+                'Eigenvalues must be sorted in descending order.');
+        end
+
+        function test_n_components_above_sqrt_n_honored(testCase)
+            % Issue #94: previously the function silently capped output at
+            % floor(sqrt(N)) components. Verify a request for more than
+            % sqrt(N) components is now honored.
+            rng(1);
+            n = 25;                          % sqrt(25) = 5
+            X = randn(n, 60);
+            Xn = X ./ vecnorm(X, 2, 2);
+            S = (Xn * Xn.' + 1) / 2;
+            S = (S + S.') / 2;
+            S(1:n+1:end) = 1;
+
+            requested = 10;                  % > sqrt(n)
+            embedding = diffusion_mapping(S, requested, 0.5, 0);
+
+            testCase.verifyEqual(size(embedding, 2), requested, ...
+                'diffusion_mapping must honor n_components > sqrt(N).');
+        end
+
+        function test_zero_row_sum_rejected(testCase)
+            % An all-zero row should raise rather than silently produce Inf.
+            S = eye(5);
+            S(3, :) = 0;
+            S(:, 3) = 0;
+
+            testCase.verifyError( ...
+                @() diffusion_mapping(S, 2, 0.5, 0), ...
+                'diffusion_mapping:zeroRowSum');
+        end
+    end
+end


### PR DESCRIPTION
Closes #98. Addresses #94 (the n_components cap noted by @ReinderVosDeWael and @annchenknodt).

## Summary
**Bug 1 — complex eigenvalues (#98).** The Markov matrix `M = D^{-1} L` constructed in `diffusion_mapping.m` is asymmetric, so `eig(M)` can return tiny imaginary parts and an unsorted spectrum, which breaks `sort(eigval, 'descend')`. The user @tw70455 traced this exactly: the MATLAB path normalizes by row only, while the Python path keeps the formulation symmetric.

Fix: solve the eigenproblem on the symmetric similar matrix
\$\$M_s = D^{-1/2} L D^{-1/2}\$\$
which has the same real eigenvalues as \$M\$. Eigenvectors map back via \$\\psi = D^{-1/2} u\$. This is mathematically equivalent to the previous formulation but numerically stable, and matches the Python implementation.

**Bug 2 — silent component cap (#94).** The previous code did `n = max(2, floor(sqrt(N)))` and then truncated `eigval(1:n)` regardless of the user-requested `n_components`. That's why @annchenknodt got a max of 17 components on a 360×360 matrix (`sqrt(360) ≈ 18.97`, minus the dropped first eigenvalue). The maintainer noted he didn't remember why this cap was there. Removed it; the function now honors `n_components` and warns only when it genuinely exceeds the matrix size.

## Test plan
- [ ] Maintainer runs MATLAB CI / existing tests to confirm no regression.
- [ ] Confirm with @tw70455's input (cosine similarity matrix, alpha=0.5, diffusion_time=0) that eigenvalues are real and properly sorted.
- [ ] Confirm @annchenknodt can request >sqrt(N) components on a 360×360 matrix without the cap kicking in.