### PR TITLE
Document offscreen VTK builds for remote/headless plotting (#66)

### DIFF
--- a/docs/pages/install.rst
+++ b/docs/pages/install.rst
@@ -57,6 +57,34 @@ Alternatively, you can install the package from Github as follows: ::
     python setup.py install
 
 
+Plotting on a remote / headless server
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+VTK requires a rendering context. On a server with no attached display
+(SSH session, container, CI runner, JupyterHub) the default ``vtk`` wheel
+will fail to render and ``plot_hemispheres`` may hang or error. Install
+one of the offscreen-capable VTK builds instead:
+
+* OSMesa (software rendering, no GPU needed): ::
+
+    pip uninstall vtk
+    pip install vtk-osmesa
+
+* EGL (GPU-accelerated, requires an NVIDIA driver with EGL support): ::
+
+    pip uninstall vtk
+    pip install vtk-egl
+
+If you prefer ``conda``, equivalent OSMesa builds are published on
+``conda-forge``: ::
+
+    conda install -c conda-forge mesalib
+    conda install -c conda-forge "vtk=*=osmesa_*"
+
+After installing, set ``embed_nb=True`` (Jupyter) or pass
+``offscreen=True`` to the plotting functions.
+
+
 
 MATLAB installation
 -------------------


### PR DESCRIPTION
Closes #66.

## Summary
The original issue captured a conda-forge recipe (`mesalib` + a pinned `vtk=*=osmesa_*` build) for getting VTK to render without a display. That recipe still works, but the modern story is much simpler: **use the prebuilt offscreen wheels from PyPI** — `vtk-osmesa` (software rendering, no GPU) or `vtk-egl` (GPU + EGL). @yusaiwen confirmed in a recent comment that these work in remote Jupyter sessions.

This PR adds a short \"Plotting on a remote / headless server\" subsection to the install guide listing both wheel names plus the conda-forge fallback.

## Test plan
- [x] Renders correctly in the docs source (`docs/pages/install.rst`).
- [ ] Maintainer eyeballs that the wheel names are still the canonical ones on PyPI.