### PR TITLE
Remove stale xfail markers (#149)

### DIFF
--- a/brainspace/tests/test_mesh.py
+++ b/brainspace/tests/test_mesh.py
@@ -109,7 +109,6 @@ def test_mesh_creation():
     assert isinstance(pd, BSPolyData)
 
 
-@pytest.mark.xfail
 def test_drop_cells():
     s = _generate_sphere()
 
@@ -149,7 +148,6 @@ def test_mask_cells():
     assert n_cells == np.count_nonzero(label_cells > 3)
 
 
-@pytest.mark.xfail
 def test_drop_points():
     s = _generate_sphere()
 


### PR DESCRIPTION
Closes #149.

`test_drop_cells` and `test_drop_points` in [brainspace/tests/test_mesh.py](brainspace/tests/test_mesh.py) were marked `@pytest.mark.xfail` but have been passing — pytest reported them as XPASS. Removed the markers so they're now hard requirements.

## Test plan
- [x] `pytest brainspace/tests/test_mesh.py` → 16 passed.
- [x] Full suite still green.