### PR TITLE
Guard PyQt5 import in plotting/utils_qt.py (#148)

### DIFF
--- a/brainspace/plotting/utils_qt.py
+++ b/brainspace/plotting/utils_qt.py
@@ -1,17 +1,19 @@
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QMainWindow
+try:
+    from PyQt5.QtCore import pyqtSignal
+    from PyQt5.QtWidgets import QMainWindow
+except ImportError:
+    MainWindow = None
+else:
+    class MainWindow(QMainWindow):
+        """Subclass of QMainWindow to capture closing event."""
 
+        signal_close = pyqtSignal()
 
-class MainWindow(QMainWindow):
-    """Subclass of QMainWindow to capture closing event."""
+        def __init__(self, parent=None):
+            """Initialize the main window."""
+            super().__init__(parent)
 
-    signal_close = pyqtSignal()
-
-    def __init__(self, parent=None):
-        """Initialize the main window."""
-        super().__init__(parent)
-
-    def closeEvent(self, event):
-        """Manage the close event."""
-        self.signal_close.emit()
-        event.accept()
+        def closeEvent(self, event):
+            """Manage the close event."""
+            self.signal_close.emit()
+            event.accept()


### PR DESCRIPTION
Closes #148.

PyQt5 is an optional plotting dependency. `brainspace/plotting/base.py` already wraps its PyQt5 imports in `try/except`, but [`brainspace/plotting/utils_qt.py`](brainspace/plotting/utils_qt.py) imported PyQt5 unconditionally at module top level. That made any direct import of `utils_qt` crash on PyQt5-less environments — fine today only because `base.py` lazy-imports it, but fragile to any future refactor.

Wrap the imports in `try/except` and expose `MainWindow = None` as a sentinel so callers can detect the unavailable case.

## Test plan
- [x] `from brainspace.plotting import utils_qt` works in environments with and without PyQt5.
- [x] Full test suite still passes (132 passed).