### PR TITLE
Move NaN/Inf and n_components validation into embedding entry points (#147)

### DIFF
--- a/brainspace/gradient/embedding.py
+++ b/brainspace/gradient/embedding.py
@@ -26,6 +26,34 @@ def _graph_is_connected(graph):
     return connected_components(graph)[0] == 1
 
 
+def _check_finite(adj, name='affinity'):
+    """Raise ValueError if `adj` contains NaN or Inf entries."""
+    if ssp.issparse(adj):
+        data = adj.data
+    else:
+        data = np.asarray(adj)
+    if data.size and (np.isnan(data).any() or np.isinf(data).any()):
+        raise ValueError(
+            'The {} matrix contains NaN or Inf values. Common causes '
+            'include NaNs/Infs or rows of zeros in the input matrix.'
+            .format(name))
+
+
+def _check_n_components(n_components, n):
+    """Validate that `n_components` is feasible for an n-by-n affinity."""
+    if n_components is None:
+        return
+    if n_components < 1:
+        raise ValueError(
+            'n_components must be >= 1; got {}.'.format(n_components))
+    # eigsh requires k < n, and we additionally compute k = n_components + 1.
+    if n_components + 1 >= n:
+        raise ValueError(
+            'n_components={} is too large for an affinity matrix of size '
+            '{}; n_components must be at most {}.'
+            .format(n_components, n, n - 2))
+
+
 def diffusion_mapping(adj, n_components=10, alpha=0.5, diffusion_time=0,
                       random_state=None):
     """Compute diffusion map of affinity matrix.
@@ -64,6 +92,9 @@ def diffusion_mapping(adj, n_components=10, alpha=0.5, diffusion_time=0,
 
     rs = check_random_state(random_state)
     use_sparse = ssp.issparse(adj)
+
+    _check_finite(adj)
+    _check_n_components(n_components, adj.shape[0])
 
     # Make symmetric
     if not is_symmetric(adj, tol=1E-10):
@@ -201,6 +232,9 @@ def laplacian_eigenmaps(adj, n_components=10, norm_laplacian=True,
     """
 
     rs = check_random_state(random_state)
+
+    _check_finite(adj)
+    _check_n_components(n_components, adj.shape[0])
 
     # Make symmetric
     if not is_symmetric(adj, tol=1E-10):

--- a/brainspace/tests/test_embedding_validation.py
+++ b/brainspace/tests/test_embedding_validation.py
@@ -1,0 +1,66 @@
+"""Tests for shared input validation across embedding entry points (#147)."""
+
+import numpy as np
+import pytest
+
+from brainspace.gradient.embedding import (
+    diffusion_mapping, laplacian_eigenmaps, DiffusionMaps, LaplacianEigenmaps,
+)
+
+
+def _psd(n, seed):
+    rs = np.random.RandomState(seed)
+    a = rs.randn(n, n + 5)
+    return a @ a.T
+
+
+def test_diffusion_mapping_rejects_nan():
+    a = _psd(8, seed=0)
+    a[0, 1] = np.nan
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        diffusion_mapping(a, n_components=2)
+
+
+def test_diffusion_mapping_rejects_inf():
+    a = _psd(8, seed=1)
+    a[2, 3] = np.inf
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        diffusion_mapping(a, n_components=2)
+
+
+def test_laplacian_eigenmaps_rejects_nan():
+    a = _psd(8, seed=2)
+    a[1, 4] = np.nan
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        laplacian_eigenmaps(a, n_components=2)
+
+
+def test_diffusion_mapping_rejects_too_large_n_components():
+    a = _psd(6, seed=3)
+    with pytest.raises(ValueError, match="too large"):
+        diffusion_mapping(a, n_components=10)
+
+
+def test_laplacian_eigenmaps_rejects_too_large_n_components():
+    a = _psd(6, seed=4)
+    with pytest.raises(ValueError, match="too large"):
+        laplacian_eigenmaps(a, n_components=10)
+
+
+def test_class_wrappers_propagate_validation():
+    a = _psd(8, seed=5)
+    a[0, 0] = np.inf
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        DiffusionMaps(n_components=2).fit(a)
+    a2 = _psd(8, seed=6)
+    a2[0, 0] = np.nan
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        LaplacianEigenmaps(n_components=2).fit(a2)
+
+
+def test_n_components_zero_or_negative_rejected():
+    a = _psd(8, seed=7)
+    with pytest.raises(ValueError, match=">= 1"):
+        diffusion_mapping(a, n_components=0)
+    with pytest.raises(ValueError, match=">= 1"):
+        laplacian_eigenmaps(a, n_components=-1)


### PR DESCRIPTION
Closes #147.

## Summary
- Add `_check_finite` and `_check_n_components` helpers in [`brainspace/gradient/embedding.py`](brainspace/gradient/embedding.py).
- Call them at the top of `diffusion_mapping` and `laplacian_eigenmaps`. `DiffusionMaps.fit` / `LaplacianEigenmaps.fit` now also reject bad inputs (they delegate to those functions).
- The NaN/Inf check that was already in `GradientMaps._fit_one` stays — both layers are now defensive in depth and the check is idempotent when reached twice.
- The new `n_components` guard prevents the cryptic ARPACK `k must be 1<=k<n` error users hit when asking for too many components on small affinity matrices.

## Test plan
- [x] New tests in [`brainspace/tests/test_embedding_validation.py`](brainspace/tests/test_embedding_validation.py) cover NaN, Inf, too-large `n_components`, zero/negative `n_components`, and class wrappers.
- [x] Full suite still passes (132 + 7 new = 139 passed).