### PR TITLE
Add CONTRIBUTING, SECURITY, and CODE_OF_CONDUCT (#146)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility, apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- Sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers listed in `CITATION.cff`. All complaints will be
+reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to BrainSpace
+
+Thank you for your interest in contributing! BrainSpace is a Python and MATLAB
+toolbox for cortical gradients. This guide describes the workflow for
+contributing code, documentation, or bug reports.
+
+## Reporting issues
+
+- **Bugs** — please include a minimal reproducer, the version of BrainSpace
+  (`brainspace.__version__`), Python version, OS, and the full traceback.
+- **Feature requests** — describe the use case before proposing an API.
+- **Security vulnerabilities** — please do not file a public issue. See
+  [SECURITY.md](SECURITY.md) for the private reporting channel.
+
+Search the existing [issue tracker](https://github.com/MICA-MNI/BrainSpace/issues)
+before opening a new one.
+
+## Development setup
+
+```bash
+git clone https://github.com/MICA-MNI/BrainSpace.git
+cd BrainSpace
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[test]"
+```
+
+To run the test suite:
+
+```bash
+pytest brainspace/
+```
+
+Plotting tests need a display. On a headless machine install one of
+`vtk-osmesa` / `vtk-egl` (see [docs/pages/install.rst](docs/pages/install.rst))
+or run under `xvfb-run`.
+
+## Pull request workflow
+
+1. Fork the repository and create a topic branch from `master`. Name it after
+   the issue it addresses, e.g. `fix-123-short-description`.
+2. Keep the change focused — one logical change per PR. Unrelated cleanup
+   belongs in its own PR.
+3. Add or update tests for any code change. New code should not regress
+   coverage.
+4. Run `pytest` locally before pushing.
+5. Open a PR against `master`. Reference the issue it closes
+   (`Closes #NNN`) in the description and include a short test plan.
+6. The CI matrix runs on Linux, macOS, and Windows across the supported
+   Python versions; PRs must be green before review.
+
+## Code style
+
+- Python: follow PEP 8; match the surrounding style in the file you're editing.
+- Public APIs need NumPy-style docstrings.
+- MATLAB: match the existing function-header style in `matlab/analysis_code/`.
+
+## Releases
+
+Maintainers tag releases via `Release v0.X.Y` commits that bump
+`brainspace/_version.py`. The `tagged_release` workflow then publishes to
+PyPI. Contributors should not bump the version in PRs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest released version of BrainSpace.
+Older versions do not receive backports.
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Instead, report privately via GitHub's
+[security advisory form](https://github.com/MICA-MNI/BrainSpace/security/advisories/new)
+or email the maintainers listed in `CITATION.cff`.
+
+A maintainer will acknowledge the report within 14 days. Once a fix is
+ready we will coordinate disclosure timing with you.


### PR DESCRIPTION
Closes #146.

GitHub's community-health checklist flagged all three files as missing. Added:

- [`CONTRIBUTING.md`](CONTRIBUTING.md): dev setup, PR workflow, branch naming convention, test command, headless plotting note.
- [`SECURITY.md`](SECURITY.md): private vulnerability reporting via GitHub security advisories.
- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md): Contributor Covenant 2.1.

The other two parts of #146 (`bugs/test.py` and `dist/`) turned out to be untracked already — both are covered by [`.gitignore`](.gitignore). Nothing to remove.

## Test plan
- [x] All three files render correctly on GitHub.
- [x] No code changes; existing tests unaffected.