### PR TITLE
Refresh packaging metadata; drop unused pandas/pillow (#144)

### DIFF
--- a/docs/pages/install.rst
+++ b/docs/pages/install.rst
@@ -9,8 +9,8 @@ BrainSpace is available in Python and MATLAB.
 Python installation
 -------------------
 
-BrainSpace works on Python 3.5+, and probably with older versions of Python 3,
-although it is not tested. 
+BrainSpace requires Python 3.9 or newer. It is tested on Python 3.9 through
+3.13 across Linux, macOS, and Windows.
 
 
 Dependencies
@@ -24,10 +24,11 @@ To use BrainSpace, the following Python packages are required:
 * `vtk <https://vtk.org/>`_
 * `matplotlib <https://matplotlib.org/>`_
 * `nibabel <https://nipy.org/nibabel/index.html>`_
-* `nilearn <https://nilearn.github.io/>`_
 
 Nibabel is required for reading/writing Gifti surfaces. Matplotlib is only
 used for colormaps and we may remove this dependency in future releases.
+``nilearn`` is only needed to run the tutorial notebooks; install it with
+``pip install brainspace[examples]``.
 
 
 Additional dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-numpy>=1.11.0
-scipy>=0.17.0
-scikit-learn>=0.22.0
-matplotlib>=2.0.0
-vtk>=9.1.0,<9.6.0
-nibabel
-nilearn
-
+numpy>=1.20
+scipy>=1.6
+scikit-learn>=0.22
+matplotlib>=3.3
+vtk>=9.1.0,<9.7.0
+nibabel>=3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst
 license_files = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,14 @@ TEST_REQUIRES = [
         'pytest', 'coverage', 'pytest-cov', 'coveralls',
     ]
 
-INSTALL_REQUIRES = ['numpy>=1.11.0',
-                    'scipy>=0.17.0',
-                    'scikit-learn>=0.20.0',
-                    'matplotlib>=2.0.0',
-                    'vtk>=9.1.0,<9.6.0',
-                    'nibabel',
-                    'pillow',
-                    'pandas']
+INSTALL_REQUIRES = ['numpy>=1.20',
+                    'scipy>=1.6',
+                    'scikit-learn>=0.22',
+                    'matplotlib>=3.3',
+                    'vtk>=9.1.0,<9.7.0',
+                    'nibabel>=3.2']
+
+EXAMPLES_REQUIRES = ['nilearn>=0.9']
 
 
 here = path.abspath(path.dirname(__file__))
@@ -49,24 +49,27 @@ setup(
     author='BrainSpace developers',
     author_email='enning.yang@mcgill.ca',
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',
         'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
         'Topic :: Scientific/Engineering',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3 :: Only',
     ],
     keywords='brain cortex gradient manifold',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    python_requires='>=3.5',
+    python_requires='>=3.9',
     install_requires=INSTALL_REQUIRES,
     extras_require={
-        'test': TEST_REQUIRES + INSTALL_REQUIRES,
+        'test': TEST_REQUIRES,
+        'examples': EXAMPLES_REQUIRES,
     },
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Closes #144.

## Summary
- `python_requires` bumped from `>=3.5` to `>=3.9`; classifiers list 3.9-3.13 to match the CI matrix.
- Development Status classifier: `3 - Alpha` -> `4 - Beta`.
- **Dropped `pandas` and `pillow`** from `INSTALL_REQUIRES`. Neither is imported anywhere under `brainspace/`; both were tutorial-only deps inflating the install footprint.
- Moved `nilearn` from base requirements to `extras_require['examples']` — it's only used by tutorial notebooks.
- Bumped dep floors to versions that actually work on supported Pythons: `numpy>=1.20`, `scipy>=1.6`, `matplotlib>=3.3`, `nibabel>=3.2`. The old `numpy>=1.11` / `scipy>=0.17` floors haven't been buildable on supported Pythons for years.
- Widened the VTK upper bound from `<9.6` to `<9.7` so users can install the most recent VTK release.
- `requirements.txt` now mirrors `install_requires` exactly, so CI and end-user installs produce the same environment.
- Fixed `description-file` -> `description_file` in `setup.cfg` (setuptools deprecation warning on every build).
- Updated [`docs/pages/install.rst`](docs/pages/install.rst) to reflect the supported Python range and the move of `nilearn` to an extra.

## Test plan
- [x] `python setup.py --version` succeeds without setuptools deprecation warnings.
- [x] Full test suite still passes (132 passed locally).
- [ ] CI matrix run on this PR once 3.12/3.13 are added (see #145).