### PR TITLE
Modernize CI workflows (#145)

### DIFF
--- a/.github/workflows/github_actions_ci.yml
+++ b/.github/workflows/github_actions_ci.yml
@@ -13,58 +13,41 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11"]
-        exclude:
-          - os: macos-latest
-            python-version: 3.7
-          - os: macos-latest
-            python-version: 3.8
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
-      - name: Test Windows
-        if: matrix.os == 'windows-latest'
+      - name: Set up headless display
+        if: matrix.os == 'ubuntu-latest'
+        uses: pyvista/setup-headless-display-action@v3
+
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest
-          python -m pip install -r requirements.txt
-          python -m pytest brainspace --ignore brainspace/tests/test_plotting.py
+          python -m pip install -e ".[test]"
 
-      - name: Prepare Linux
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install pytest
-          python3 -m pip install -r requirements.txt
+      - name: Test (Linux / macOS)
+        if: matrix.os != 'windows-latest'
+        run: python -m pytest brainspace
 
-      - name: Test Linux
-        if: matrix.os == 'ubuntu-latest'
-        uses: GabrielBB/xvfb-action@v1.5
-        with:
-          options: -screen 0 1600x1200x24
-          run: python3 -m pytest brainspace
-
-      - name: Test macOS
-        if: matrix.os == 'macos-latest'
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install pytest
-          python3 -m pip install -r requirements.txt
-          python3 -m pytest brainspace
+      - name: Test (Windows, no plotting)
+        if: matrix.os == 'windows-latest'
+        run: python -m pytest brainspace --ignore brainspace/tests/test_plotting.py
 
   matlab_unittests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v0
+        uses: matlab-actions/setup-matlab@v2
       - name: Run tests
-        uses: matlab-actions/run-tests@v0
+        uses: matlab-actions/run-tests@v2
         with:
           source-folder: matlab

--- a/.github/workflows/python_coverage.yml
+++ b/.github/workflows/python_coverage.yml
@@ -7,23 +7,25 @@ on:
 jobs:
   codecov:
     name: Codecov Workflow
-    runs-on: macos-latest
-    
+    runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@master
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.11"
+          cache: pip
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@v3
       - name: Generate coverage report
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install pytest pytest-cov
-          python3 -m pip install -r requirements.txt
-          python3 -m pytest --cov=./ --cov-report=xml 
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+          python -m pytest --cov=brainspace --cov-report=xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests

--- a/.github/workflows/tagged_release.yml
+++ b/.github/workflows/tagged_release.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Closes #145.

## Summary

### `github_actions_ci.yml`
- `actions/checkout` v2 → v4, `actions/setup-python` v2 → v5 (drops the Node 16 deprecation warnings).
- **Drop `GabrielBB/xvfb-action@v1.5`** (unmaintained) → `pyvista/setup-headless-display-action@v3`, which is actively maintained and is the standard for VTK/PyVista CI.
- Matrix moved to Python `3.9, 3.10, 3.11, 3.12, 3.13` — drops EOL `3.7`/`3.8`, matches the metadata refresh in #144.
- Install via `pip install -e ".[test]"` so CI exercises the same `setup.py` metadata end users get from PyPI (instead of `requirements.txt` + ad-hoc `pip install pytest`).
- `matlab-actions/setup-matlab` and `run-tests` v0 → v2.
- Cache pip downloads via `setup-python`'s `cache: pip`.

### `python_coverage.yml`
- `actions/checkout@v1` → v4, `actions/setup-python@master` (unsafe floating tag) → v5, `codecov/codecov-action@v1` → v4.
- Run on `ubuntu-latest` with a headless display instead of `macos-latest` (faster runner, plotting tests now actually exercise the rendering path during coverage).
- Use `--cov=brainspace` instead of `--cov=./` to scope coverage to the package.

### `tagged_release.yml`
- `actions/checkout` v3 → v4, `actions/setup-python` v3 → v5; align Python pin.

## Test plan
- [ ] CI run on this PR is green across the full matrix.
- [ ] Codecov upload succeeds and reports coverage scoped to `brainspace/`.