### PR TITLE
Enable Qt backend for image rendering (#136)

### DIFF
--- a/brainspace/plotting/base.py
+++ b/brainspace/plotting/base.py
@@ -91,7 +91,7 @@ def _get_qt_app():
     if in_ipython():
         from IPython import get_ipython
         ipython = get_ipython()
-        ipython.magic('gui qt')
+        ipython.run_line_magic('gui', 'qt')
 
         from IPython.external.qt_for_kernel import QtGui
         app = QtGui.QApplication.instance()
@@ -191,10 +191,6 @@ class Plotter(object):
 
     def __init__(self, nrow=1, ncol=1, offscreen=None, force_close=False,
                  try_qt=False, **kwargs):
-
-        if try_qt:
-            warnings.warn('Qt rendering is not supported for the moment.')
-            try_qt = False
 
         self.grid = _create_grid(nrow, ncol)
         self.nrow, self.ncol = self.grid.shape[:2]
@@ -341,7 +337,11 @@ class Plotter(object):
 
             self.ren_win.Render()
             if self.use_qt:
+                # Qt event loop is blocking: show() returns immediately,
+                # exec_() spins until the user closes the window. Without
+                # this the program hangs after window close (issue #136).
                 self.app_window.show()
+                self.app.exec_()
             else:
                 self.iren.Start()
 

--- a/brainspace/tests/test_plotting.py
+++ b/brainspace/tests/test_plotting.py
@@ -17,6 +17,12 @@ try:
 except ImportError:
     ipy = None
 
+try:
+    import PyQt5  # noqa: F401
+    has_pyqt5 = True
+except ImportError:
+    has_pyqt5 = False
+
 
 from brainspace.vtk_interface.pipeline import to_data
 from brainspace.plotting.base import Plotter
@@ -142,3 +148,19 @@ def test_plot_hemispheres():
     s2 = to_data(vtk.vtkSphereSource())
 
     plot_hemispheres(s1, s2, offscreen=True)
+
+
+def test_try_qt_no_longer_warns_unsupported():
+    """try_qt=True must not emit the old 'Qt rendering is not supported' warning (#136).
+
+    We pass offscreen=True so no actual Qt window is built (that requires a
+    display and would crash on headless CI). The check is purely that the
+    warn-and-disable shim is gone.
+    """
+    import warnings as _warnings
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter('always')
+        Plotter(offscreen=True, try_qt=True).close()
+    assert not any(
+        'Qt rendering is not supported' in str(x.message) for x in w
+    )


### PR DESCRIPTION
Supersedes #136 (kept open for history; will be closed on merge).

This is @RicardoRyn's fix from #136 with the review feedback applied:

- **`base.py:94`** — `ipython.magic('gui qt')` → `ipython.run_line_magic('gui', 'qt')` (deprecated since IPython 7.0).
- **`base.py:195-197`** — delete the `try_qt` warn-and-disable shim entirely (was commented out in #136).
- **`base.py:339-345`** — add `self.app.exec_()` after `self.app_window.show()`. Without it the Qt event loop never spins, so closing the window doesn't terminate `show()`.
- **New test** `test_try_qt_no_longer_warns_unsupported` asserts the old \"Qt rendering is not supported\" warning is gone. Uses `offscreen=True` so no real window is built (constructing a Qt window without a display segfaults on headless macOS).

Note: `app.exec_()` is **blocking**. When `try_qt=True`, `Plotter.show()` now spins the Qt event loop until the user closes the window. That's the intended fix but a behavioral change — added an inline comment explaining it.

## Test plan
- [x] `pytest brainspace/tests/` → 143 passed, 1 xfailed (excluding the existing plotting tests that need a display).
- [x] New \`test_try_qt_no_longer_warns_unsupported\` passes.
- [ ] Manual verification on a desktop with PyQt5 that closing the window now exits cleanly.

Closes #136.