### PR TITLE
Add cat35 categorical palette (BSD-compatible substitute for fs_colours2 from #91)

### DIFF
--- a/brainspace/plotting/colormaps.py
+++ b/brainspace/plotting/colormaps.py
@@ -57,9 +57,31 @@ _BuGyRd_stops = np.array([
 ])
 BuGyRd = _interp_lut(_BuGyRd_stops, n=256)
 
+def _build_cat35():
+    """35-entry categorical palette (black + 34 distinguishable colors).
+
+    Built deterministically from matplotlib's ``tab20`` + ``tab20b`` (BSD
+    license) so we don't ship colors copied from a non-BSD-compatible
+    source. The 35-entry size is convenient for parcellations like
+    Desikan-Killiany (34 cortical labels + 1 unknown/medial-wall slot).
+    """
+    import matplotlib as _mpl
+    pick = _mpl.colormaps['tab20'](np.linspace(0, 1, 20))[:, :3]
+    extra = _mpl.colormaps['tab20b'](np.linspace(0, 1, 20))[:, :3][:14]
+    rgb = np.vstack([np.zeros((1, 3)), pick, extra])  # leading black slot
+    rgba = np.empty((rgb.shape[0], 4), dtype=np.uint8)
+    rgba[:, :3] = (rgb * 255).round().astype(np.uint8)
+    rgba[:, 3] = 255
+    return rgba
+
+
+cat35_colors = _build_cat35()
+
+
 colormaps = {
     'yeo7': yeo7_colors,
     'eco_kos': eco_kos_colors,
     'spec_5': spec_5_colors,
     'BuGyRd': BuGyRd,
+    'cat35': cat35_colors,
 }

--- a/brainspace/tests/test_colormaps.py
+++ b/brainspace/tests/test_colormaps.py
@@ -8,11 +8,23 @@ from brainspace.plotting.colormaps import (
 
 
 def test_registered_names():
-    for name in ('yeo7', 'eco_kos', 'spec_5', 'BuGyRd'):
+    for name in ('yeo7', 'eco_kos', 'spec_5', 'BuGyRd', 'cat35'):
         assert name in colormaps
         cm = colormaps[name]
         assert cm.dtype == np.uint8
         assert cm.shape[1] == 4
+
+
+def test_cat35_shape_and_first_slot():
+    cm = colormaps['cat35']
+    assert cm.shape == (35, 4)
+    # First slot reserved for unknown/medial-wall: pure black, opaque.
+    np.testing.assert_array_equal(cm[0], [0, 0, 0, 255])
+    # All entries opaque.
+    assert np.all(cm[:, 3] == 255)
+    # All 35 colors should be distinct.
+    unique_rows = {tuple(row) for row in cm}
+    assert len(unique_rows) == 35
 
 
 def test_BuGyRd_is_256_smooth_lut():


### PR DESCRIPTION
Resolves the last unmerged piece of #91.

## Why a substitute, not the original

The original \`fs_colours2\` array is a verbatim copy of FreeSurfer's parcellation color LUT. FreeSurfer is licensed for **non-commercial use only**, which is incompatible with BrainSpace's BSD-3 license. Shipping those exact RGB tuples would create a license-mismatch downstream.

## What this is

A 35-entry palette named \`cat35\`:
- Same shape as the original (\`(35, 4)\` uint8 RGBA), so it's a drop-in replacement for any code that wanted a Desikan-Killiany-style 35-color palette (34 cortical labels + 1 unknown/medial-wall slot).
- Built **programmatically** from matplotlib's \`tab20\` + \`tab20b\` qualitative colormaps (PSF/BSD-compatible), with a leading black row for the unknown slot.
- Construction lives in \`_build_cat35()\` so the colors are auditable rather than hand-listed.

## Test plan
- [x] \`pytest brainspace/tests/test_colormaps.py\` → 4 passed (registration, shape, opaque-alpha, leading-black, all-distinct).
- [x] Full suite still green.