### PR TITLE
Release v0.2.1: fix Colormap-instance cmap argument (#162)

### DIFF
--- a/brainspace/_version.py
+++ b/brainspace/_version.py
@@ -1,3 +1,3 @@
 """BrainSpace version"""
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'


### PR DESCRIPTION
## Summary

- Bump `__version__` to `0.2.1`.
- Patch release covering the Colormap-instance `cmap` bug fix landed in #162 (`TypeError: unhashable type: 'ListedColormap'` when passing a matplotlib `Colormap` object as `cmap`).

## Test plan
- [x] Local pytest on `brainspace/tests/test_plotting.py` and `brainspace/tests/test_colormaps.py` (19 passed) on top of `dd6a5a8`.
- [ ] CI green.

After merge: tag `v0.2.1` from the merge commit and publish a GitHub release; the existing `tagged_release.yml` workflow then builds and updates the `latest` release artifacts.
